### PR TITLE
EtalonDriftModel: better explain math

### DIFF
--- a/BayesicFitting/source/EtalonDriftModel.py
+++ b/BayesicFitting/source/EtalonDriftModel.py
@@ -36,7 +36,7 @@ class EtalonDriftModel( NonLinearModel ):
     """
     Sinusoidal Model with drifting frequency.
     .. math::
-        f( x,y:p ) = p_0 / ( 1.0 + p_1 * sin^2( \pi p_2 x + p_3 + p_4 y ) )
+        f( x,y:p ) = p_0 / ( 1.0 + p_1^2 * sin^2( \pi ( p_2 x + p_3 + p_4 y ) ) )
 
     where :math:`p_0` = amplitude, :math:`p_1` = finesse,
     :math:`p_2` = periods per wavenumber, :math:`p_3` = phase,


### PR DESCRIPTION
Adjusted documentation of EtalonDriftModel to better reflect what's actually calculated:

* p_1 enters squared
* entire argument to \sin is multiplied by \pi, not just p_2*x