### PR TITLE
Include license in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include BayesicFitting/examples/data/*.csv
 include BayesicFitting/documentation/images/*.dia
 include BayesicFitting/documentation/images/*.png
 include BayesicFitting/documentation/*.md
-
+include LICENSE


### PR DESCRIPTION
The terms of the GPL require the license be included in all copies of the program.