### PR TITLE
MNT: Remove unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+ci:
+  autoupdate_schedule: monthly
+
+repos:
+  # lint
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.3
+    hooks:
+      - id: ruff-check
+        args:
+          - --fix
+          - --show-fixes

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,10 @@
+exclude = [
+    "__init__.py",
+    "setup.py",
+    "*.ipynb",
+]
+
+[lint]
+select = [
+    "F401",  # Unused imports
+]

--- a/BayesicFitting/source/AmoebaFitter.py
+++ b/BayesicFitting/source/AmoebaFitter.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-import math
-from . import Tools
 
 from .MaxLikelihoodFitter import MaxLikelihoodFitter
 from .AnnealingAmoeba import AnnealingAmoeba

--- a/BayesicFitting/source/AstropyModel.py
+++ b/BayesicFitting/source/AstropyModel.py
@@ -1,11 +1,7 @@
 import numpy as numpy
-from astropy import units
-from astropy.modeling import Model as AstroModel
 from astropy.modeling import FittableModel
-import math
 from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 
 from .Model import Model
 

--- a/BayesicFitting/source/BSplinesModel.py
+++ b/BayesicFitting/source/BSplinesModel.py
@@ -1,7 +1,6 @@
 import numpy as numpy
 from . import Tools
 from .Tools import setAttribute as setatt
-import math
 # import (modified) bspline from Juha Jeronen
 from . import bspline
 from . import splinelab

--- a/BayesicFitting/source/BaseFitter.py
+++ b/BayesicFitting/source/BaseFitter.py
@@ -1,12 +1,9 @@
 import numpy as numpy
 import math
-import warnings
-import matplotlib.pyplot as plt
 from astropy.table import Table
 
 from .ImageAssistant import ImageAssistant
 from .MonteCarlo import MonteCarlo
-from .ConvergenceError import ConvergenceError
 from . import Tools
 from . import Plotter
 from .Formatter import formatter as fmt

--- a/BayesicFitting/source/BasicSplinesModel.py
+++ b/BayesicFitting/source/BasicSplinesModel.py
@@ -1,15 +1,11 @@
 import numpy as numpy
 from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
-import matplotlib.pyplot as plt
 
 from .SplinesModel import SplinesModel
 from .PolynomialModel import PolynomialModel
 
 
-from .kernels.Kernel import Kernel
-from .kernels.Tophat import Tophat
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/BernoulliErrorDistribution.py
+++ b/BayesicFitting/source/BernoulliErrorDistribution.py
@@ -1,8 +1,6 @@
 import numpy as numpy
 import math
 
-from .Formatter import formatter as fmt
-from .Formatter import fma
 from .ErrorDistribution import ErrorDistribution
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/BracketModel.py
+++ b/BayesicFitting/source/BracketModel.py
@@ -1,8 +1,4 @@
-import numpy
-from .Model import Model
 from .Model import Brackets
-from . import Tools
-from .Tools import setAttribute as setatt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/CauchyErrorDistribution.py
+++ b/BayesicFitting/source/CauchyErrorDistribution.py
@@ -3,7 +3,6 @@ import scipy
 import math
 
 from .ScaledErrorDistribution import ScaledErrorDistribution
-from .NoiseScale import NoiseScale
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/ChebyshevPolynomialModel.py
+++ b/BayesicFitting/source/ChebyshevPolynomialModel.py
@@ -2,7 +2,6 @@ import numpy as numpy
 from . import Tools
 from .Tools import setAttribute as setatt
 
-from astropy import units
 from .LinearModel import LinearModel
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/ChordEngine.py
+++ b/BayesicFitting/source/ChordEngine.py
@@ -1,7 +1,6 @@
 import numpy as numpy
 import math
 import warnings
-from . import Tools
 
 from .Engine import Engine
 from .Engine import DummyPlotter

--- a/BayesicFitting/source/ClassicProblem.py
+++ b/BayesicFitting/source/ClassicProblem.py
@@ -1,12 +1,6 @@
 import numpy as numpy
-from astropy import units
-import re
-import warnings
-from . import Tools
 
 from .Problem import Problem
-from .Dynamic import Dynamic
-from .Modifiable import Modifiable
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/CombiModel.py
+++ b/BayesicFitting/source/CombiModel.py
@@ -1,12 +1,8 @@
 import numpy as numpy
-from astropy import units
-import math
 import re
-from . import Tools
 from .Tools import setAttribute as setatt
 
 from .BracketModel import BracketModel
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/ConvergenceError.py
+++ b/BayesicFitting/source/ConvergenceError.py
@@ -1,7 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
-from . import Tools
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/CurveFitter.py
+++ b/BayesicFitting/source/CurveFitter.py
@@ -1,14 +1,9 @@
 import numpy as numpy
-from astropy import units
 from scipy.optimize import curve_fit
 import math
 from . import Tools
-from .Formatter import formatter as fmt
 
-from .ConvergenceError import ConvergenceError
-from .BaseFitter import BaseFitter
 from .IterativeFitter import IterativeFitter
-from .IterationPlotter import IterationPlotter
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/DeathEngine.py
+++ b/BayesicFitting/source/DeathEngine.py
@@ -1,6 +1,5 @@
 import numpy as numpy
 
-from . import Tools
 from .Formatter import formatter as fmt
 from .Dynamic import Dynamic
 from .Engine import Engine

--- a/BayesicFitting/source/DecisionTreeModel.py
+++ b/BayesicFitting/source/DecisionTreeModel.py
@@ -1,16 +1,12 @@
 import numpy as numpy
-from astropy import units
-import math
 
 from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 
 from .LinearModel import LinearModel
 from .Dynamic import Dynamic
 from .Modifiable import Modifiable
 from .ExponentialPrior import ExponentialPrior
-from .UniformPrior import UniformPrior
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/DistanceCostFunction.py
+++ b/BayesicFitting/source/DistanceCostFunction.py
@@ -2,9 +2,6 @@ import numpy as numpy
 import math
 
 from .ErrorDistribution import ErrorDistribution
-from .LogFactorial import logFactorial
-from .Formatter import formatter as fmt
-from .Tools import setAttribute as setatt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/Dynamic.py
+++ b/BayesicFitting/source/Dynamic.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-from . import Tools
-from .Formatter import formatter as fmt
 from .Tools import setAttribute as setatt
 from .Prior import Prior
 from .ExponentialPrior import ExponentialPrior

--- a/BayesicFitting/source/Engine.py
+++ b/BayesicFitting/source/Engine.py
@@ -4,8 +4,6 @@ from . import Tools
 
 from .LevenbergMarquardtFitter import LevenbergMarquardtFitter
 from .Walker import Walker
-from .PhantomCollection import PhantomCollection
-from .Formatter import formatter as fmt
 from .Tools import setAttribute as setatt
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/ErrorDistribution.py
+++ b/BayesicFitting/source/ErrorDistribution.py
@@ -4,7 +4,6 @@ import math
 from .HyperParameter import HyperParameter
 from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
  
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/ErrorsInXandYProblem.py
+++ b/BayesicFitting/source/ErrorsInXandYProblem.py
@@ -1,12 +1,8 @@
 import numpy as numpy
-from astropy import units
-import re
-import warnings
 from . import Tools
 from .Tools import setAttribute as setatt
 
 from .Problem import Problem
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/EtalonModel.py
+++ b/BayesicFitting/source/EtalonModel.py
@@ -2,7 +2,6 @@ import numpy as numpy
 from astropy import units
 import math
 from . import Tools
-from .Tools import setAttribute as setatt
 from .NonLinearModel import NonLinearModel
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/EvidenceProblem.py
+++ b/BayesicFitting/source/EvidenceProblem.py
@@ -1,12 +1,6 @@
 import numpy as numpy
-from astropy import units
-import re
-import warnings
-from . import Tools
 
 from .ClassicProblem import ClassicProblem
-from .Dynamic import Dynamic
-from .Modifiable import Modifiable
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/Explorer.py
+++ b/BayesicFitting/source/Explorer.py
@@ -2,9 +2,7 @@ import numpy as numpy
 from threading import Thread
 
 from .Engine import Engine
-from .ModelDistribution import ModelDistribution
 from .Formatter import formatter as fmt
-from . import Tools
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/ExponentialPrior.py
+++ b/BayesicFitting/source/ExponentialPrior.py
@@ -1,7 +1,6 @@
 import math as math
 import random as random
 
-from .Tools import setAttribute as setatt
 from .LaplacePrior import LaplacePrior
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/Fitter.py
+++ b/BayesicFitting/source/Fitter.py
@@ -1,7 +1,6 @@
 import numpy as numpy
 from .BaseFitter import BaseFitter
 
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/FixedModel.py
+++ b/BayesicFitting/source/FixedModel.py
@@ -1,13 +1,10 @@
 import numpy as numpy
-from astropy import units
 import re
-import string
 import warnings
 from . import Tools
 
 from .BaseModel import BaseModel
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/FootballModel.py
+++ b/BayesicFitting/source/FootballModel.py
@@ -1,9 +1,7 @@
 import numpy as numpy
 from astropy import units
 from .NonLinearModel import NonLinearModel
-from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/Formatter.py
+++ b/BayesicFitting/source/Formatter.py
@@ -1,11 +1,7 @@
 from __future__ import print_function
 
-from collections.abc import Iterable
 import numpy as numpy
 from numpy import ndarray
-from numpy import float64
-from numpy import int64
-import math
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/FreeShapeModel.py
+++ b/BayesicFitting/source/FreeShapeModel.py
@@ -1,11 +1,8 @@
 import numpy as numpy
 import numpy.linalg
-from astropy import units
-import math
 
 from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 from .LinearModel import LinearModel
 from .kernels.Kernel import Kernel
 from .kernels.Tophat import Tophat

--- a/BayesicFitting/source/GalileanEngine.py
+++ b/BayesicFitting/source/GalileanEngine.py
@@ -1,9 +1,6 @@
 import numpy as numpy
-from astropy import units
 import math
-import warnings
 import sys
-from . import Tools
 from .Formatter import formatter as fmt
 from .Formatter import fma
 

--- a/BayesicFitting/source/GaussErrorDistribution.py
+++ b/BayesicFitting/source/GaussErrorDistribution.py
@@ -2,7 +2,6 @@ import numpy as numpy
 import math
 
 from .ScaledErrorDistribution import ScaledErrorDistribution
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/GaussModel.py
+++ b/BayesicFitting/source/GaussModel.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
 from . import Tools
 from .Tools import setAttribute as setatt
 

--- a/BayesicFitting/source/GaussPrior.py
+++ b/BayesicFitting/source/GaussPrior.py
@@ -2,7 +2,6 @@ import math
 import numpy
 from scipy import special
 
-from .Formatter import formatter as fmt
 from .Prior import Prior
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/GibbsEngine.py
+++ b/BayesicFitting/source/GibbsEngine.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-from . import Tools
 from .Formatter import formatter as fmt
 from .Formatter import fma
 

--- a/BayesicFitting/source/HarmonicDynamicModel.py
+++ b/BayesicFitting/source/HarmonicDynamicModel.py
@@ -1,7 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
-from .import Tools
 from .Tools import setAttribute as setatt
 
 from .HarmonicModel import HarmonicModel

--- a/BayesicFitting/source/HarmonicModel.py
+++ b/BayesicFitting/source/HarmonicModel.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-from astropy import units
 import math
 from . import Tools
 from .Tools import setAttribute as setatt

--- a/BayesicFitting/source/HyperParameter.py
+++ b/BayesicFitting/source/HyperParameter.py
@@ -1,8 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
-from . import Tools
-from .Prior import Prior
 from .JeffreysPrior import JeffreysPrior
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/ImageAssistant.py
+++ b/BayesicFitting/source/ImageAssistant.py
@@ -1,7 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
-from . import Tools
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/IterationPlotter.py
+++ b/BayesicFitting/source/IterationPlotter.py
@@ -1,8 +1,5 @@
 import time
 import numpy as numpy
-from astropy import units
-import math
-from . import Tools
 import matplotlib.pyplot as pyplot
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/IterativeFitter.py
+++ b/BayesicFitting/source/IterativeFitter.py
@@ -1,14 +1,8 @@
 import numpy as numpy
-import math
 
 from .ConvergenceError import ConvergenceError
 from .BaseFitter import BaseFitter
 from .IterationPlotter import IterationPlotter
-from .GaussErrorDistribution import GaussErrorDistribution
-from .LaplaceErrorDistribution import LaplaceErrorDistribution
-from .CauchyErrorDistribution import CauchyErrorDistribution
-from .PoissonErrorDistribution import PoissonErrorDistribution
-from .ExponentialErrorDistribution import ExponentialErrorDistribution
 from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/JeffreysPrior.py
+++ b/BayesicFitting/source/JeffreysPrior.py
@@ -3,7 +3,6 @@ import numpy as numpy
 import warnings
 
 from .Prior import Prior
-from .Tools import setAttribute as setatt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/Kepplers2ndLaw.py
+++ b/BayesicFitting/source/Kepplers2ndLaw.py
@@ -1,10 +1,7 @@
 import numpy as numpy
 import math
-import warnings
 
-from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/KernelModel.py
+++ b/BayesicFitting/source/KernelModel.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
 from . import Tools
 from .Tools import setAttribute as setatt
 

--- a/BayesicFitting/source/LaplaceErrorDistribution.py
+++ b/BayesicFitting/source/LaplaceErrorDistribution.py
@@ -1,7 +1,6 @@
 import numpy as numpy
 import math
 
-from .Formatter import formatter as fmt
 from .ScaledErrorDistribution import ScaledErrorDistribution
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/LevenbergMarquardtFitter.py
+++ b/BayesicFitting/source/LevenbergMarquardtFitter.py
@@ -1,11 +1,8 @@
 import numpy as numpy
-from astropy import units
 import math
-from . import Tools
 
 from .IterativeFitter import IterativeFitter
 from .ConvergenceError import ConvergenceError
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/LinearModel.py
+++ b/BayesicFitting/source/LinearModel.py
@@ -1,7 +1,6 @@
 import numpy as numpy
 from .Model import Model
 
-from .Formatter import formatter as fmt
 
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/LogisticModel.py
+++ b/BayesicFitting/source/LogisticModel.py
@@ -1,8 +1,5 @@
 import numpy as numpy
-from astropy import units
-import math
 from . import Tools
-from .Tools import setAttribute as setatt
 
 from .NonLinearModel import NonLinearModel
 

--- a/BayesicFitting/source/LoopEngine.py
+++ b/BayesicFitting/source/LoopEngine.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-import math
 from . import Tools
 from .Formatter import formatter as fmt
 

--- a/BayesicFitting/source/MaxLikelihoodFitter.py
+++ b/BayesicFitting/source/MaxLikelihoodFitter.py
@@ -10,7 +10,6 @@ from .PoissonErrorDistribution import PoissonErrorDistribution
 from .ExponentialErrorDistribution import ExponentialErrorDistribution
 from .ClassicProblem import ClassicProblem
 
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/MixedErrorDistribution.py
+++ b/BayesicFitting/source/MixedErrorDistribution.py
@@ -7,7 +7,6 @@ from .ErrorDistribution import ErrorDistribution
 from .HyperParameter import HyperParameter
 from .UniformPrior import UniformPrior
 from . import Tools
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/Model.py
+++ b/BayesicFitting/source/Model.py
@@ -10,7 +10,6 @@ from .FixedModel import FixedModel
 #from .UniformPrior import UniformPrior
 from . import Tools
 from .Formatter import formatter as fmt
-from .Formatter import fma
 from .Tools import setAttribute as setatt
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/ModelDistribution.py
+++ b/BayesicFitting/source/ModelDistribution.py
@@ -10,7 +10,6 @@ from .BaseFitter import BaseFitter
 from .CurveFitter import CurveFitter
 from .AmoebaFitter import AmoebaFitter
 from .LevenbergMarquardtFitter import LevenbergMarquardtFitter
-from .Formatter import formatter as fmt
 from .Tools import setAttribute as setatt
 
 

--- a/BayesicFitting/source/MonteCarlo.py
+++ b/BayesicFitting/source/MonteCarlo.py
@@ -1,8 +1,6 @@
 import numpy as numpy
 from . import Tools
-import math
 
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/MoveEngine.py
+++ b/BayesicFitting/source/MoveEngine.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-import math
-from . import Tools
 from .Formatter import formatter as fmt
 
 from .OrderEngine import OrderEngine

--- a/BayesicFitting/source/MultipleOutputProblem.py
+++ b/BayesicFitting/source/MultipleOutputProblem.py
@@ -1,7 +1,6 @@
 import numpy as numpy
 
 from .Problem import Problem
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/NearEngine.py
+++ b/BayesicFitting/source/NearEngine.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-import math
-from . import Tools
 from .Formatter import formatter as fmt
 
 from .OrderEngine import OrderEngine

--- a/BayesicFitting/source/NestedSampler.py
+++ b/BayesicFitting/source/NestedSampler.py
@@ -1,10 +1,8 @@
 from __future__ import print_function
 
 import numpy as numpy
-from astropy import units
 import math
 from . import Tools
-from .Tools import setAttribute as setatt
 from .Formatter import formatter as fmt
 from . import Plotter
 import sys
@@ -12,10 +10,8 @@ import warnings
 import matplotlib.pyplot as plt
 
 from .Explorer import Explorer
-from .Model import Model
 from .Walker import Walker
 from .WalkerList import WalkerList
-from .Sample import Sample
 from .SampleList import SampleList
 
 from .Problem import Problem

--- a/BayesicFitting/source/NestedSolver.py
+++ b/BayesicFitting/source/NestedSolver.py
@@ -1,24 +1,10 @@
 import numpy as numpy
-from astropy import units
-import math
-from . import Tools
-from .Formatter import formatter as fmt
-from . import Plotter
-import sys
-import warnings
-import matplotlib.pyplot as plt
 
-from .Problem import Problem
-from .Walker import Walker
-from .WalkerList import WalkerList
-from .Sample import Sample
-from .SampleList import SampleList
 from .ErrorDistribution import ErrorDistribution
 
 from .NestedSampler import NestedSampler
 
 ## for Order Problems import the classes
-from .OrderProblem import OrderProblem
 from .DistanceCostFunction import DistanceCostFunction
 from .StartOrderEngine import StartOrderEngine
 #from .StartNearEngine import StartNearEngine

--- a/BayesicFitting/source/NeuralNetUtilities.py
+++ b/BayesicFitting/source/NeuralNetUtilities.py
@@ -1,9 +1,5 @@
 import numpy as numpy
-from astropy import units
-import math
 from . import Tools
-from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/NoiseScale.py
+++ b/BayesicFitting/source/NoiseScale.py
@@ -1,7 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
-from . import Tools
 
 from .HyperParameter import HyperParameter
 from .JeffreysPrior import JeffreysPrior

--- a/BayesicFitting/source/NonLinearModel.py
+++ b/BayesicFitting/source/NonLinearModel.py
@@ -1,5 +1,4 @@
 from .Model import Model
-from . import Tools
 from .Tools import setAttribute as setatt
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/OrderEngine.py
+++ b/BayesicFitting/source/OrderEngine.py
@@ -1,7 +1,4 @@
 import numpy as numpy
-import math
-from . import Tools
-from .Formatter import formatter as fmt
 
 from .Engine import Engine
 

--- a/BayesicFitting/source/OrderProblem.py
+++ b/BayesicFitting/source/OrderProblem.py
@@ -1,10 +1,6 @@
 import numpy as numpy
-from astropy import units
-import re
-import warnings
 from .Problem import Problem
 from .Dynamic import Dynamic
-from . import Tools
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/OrthonormalBasis.py
+++ b/BayesicFitting/source/OrthonormalBasis.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-from . import Tools
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/PadeModel.py
+++ b/BayesicFitting/source/PadeModel.py
@@ -1,11 +1,8 @@
 import numpy as numpy
-from astropy import units
-import math
 from . import Tools
 from .Tools import setAttribute as setatt
 
 from .NonLinearModel import NonLinearModel
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/PhantomCollection.py
+++ b/BayesicFitting/source/PhantomCollection.py
@@ -1,10 +1,7 @@
 import numpy as numpy
 import math
 
-from .Walker import Walker
 from .WalkerList import WalkerList
-from .Formatter import formatter as fmt
-from . import Tools
 
 __author__ = "Do Kester"
 __year__ = 2024

--- a/BayesicFitting/source/PhantomSampler.py
+++ b/BayesicFitting/source/PhantomSampler.py
@@ -1,51 +1,16 @@
 from __future__ import print_function
 
 import numpy as numpy
-from astropy import units
 import math
-from . import Tools
-from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
-from .Formatter import fma
-from . import Plotter
-import sys
-import warnings
-import matplotlib.pyplot as plt
 
 from .NestedSampler import NestedSampler
 
 
-from .Explorer import Explorer
-from .Model import Model
-from .Walker import Walker
-from .WalkerList import WalkerList
-from .Sample import Sample
-from .SampleList import SampleList
 
-from .Problem import Problem
-from .ClassicProblem import ClassicProblem
-from .ErrorsInXandYProblem import ErrorsInXandYProblem
 
-from .ErrorDistribution import ErrorDistribution
-from .ScaledErrorDistribution import ScaledErrorDistribution
-from .GaussErrorDistribution import GaussErrorDistribution
-from .LaplaceErrorDistribution import LaplaceErrorDistribution
-from .PoissonErrorDistribution import PoissonErrorDistribution
-from .CauchyErrorDistribution import CauchyErrorDistribution
-from .UniformErrorDistribution import UniformErrorDistribution
-from .ExponentialErrorDistribution import ExponentialErrorDistribution
 
-from .Engine import Engine
-from .StartEngine import StartEngine
-from .ChordEngine import ChordEngine
-from .GibbsEngine import GibbsEngine
-from .GalileanEngine import GalileanEngine
-from .StepEngine import StepEngine
 ## for Dynamic Models import the classes
-from .BirthEngine import BirthEngine
-from .DeathEngine import DeathEngine
 ## for Modifiable Models:
-from .StructureEngine import StructureEngine
 
 __author__ = "Do Kester"
 __year__ = 2023

--- a/BayesicFitting/source/Plotter.py
+++ b/BayesicFitting/source/Plotter.py
@@ -2,9 +2,7 @@ import numpy as numpy
 import math as math
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
-from numpy.testing import assert_array_almost_equal as assertAAE
 from . import Tools
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/PolySurfaceModel.py
+++ b/BayesicFitting/source/PolySurfaceModel.py
@@ -1,7 +1,6 @@
 import numpy as numpy
 from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 
 from .LinearModel import LinearModel
 

--- a/BayesicFitting/source/PowerLawModel.py
+++ b/BayesicFitting/source/PowerLawModel.py
@@ -1,6 +1,5 @@
 import numpy as numpy
 from astropy import units
-import math
 from . import Tools
 from .NonLinearModel import NonLinearModel
 

--- a/BayesicFitting/source/Prior.py
+++ b/BayesicFitting/source/Prior.py
@@ -1,9 +1,7 @@
 import numpy as numpy
 import math as math
-import warnings
 
 from .Tools import setAttribute as setatt
-from .Tools import printclass
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/Problem.py
+++ b/BayesicFitting/source/Problem.py
@@ -1,11 +1,9 @@
 import numpy as numpy
-import re
 
 from .Tools import shortName as ToolsShortName
 from .Tools import setAttribute as setatt
 from .Tools import printclass as printclass
 
-from .Dynamic import Dynamic
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/PseudoVoigtModel.py
+++ b/BayesicFitting/source/PseudoVoigtModel.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-import math
-from . import Tools
 from .Tools import setAttribute as setatt
 from .NonLinearModel import NonLinearModel
 from .LorentzModel import LorentzModel

--- a/BayesicFitting/source/RepeatingModel.py
+++ b/BayesicFitting/source/RepeatingModel.py
@@ -1,15 +1,11 @@
 import numpy as numpy
-from astropy import units
-import math
 from . import Tools
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
 
 from .Model import Model
 from .Dynamic import Dynamic
 from .ExponentialPrior import ExponentialPrior
 from .UniformPrior import UniformPrior
-from .Prior import Prior
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/ReverseEngine.py
+++ b/BayesicFitting/source/ReverseEngine.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-import math
-from . import Tools
 from .Formatter import formatter as fmt
 
 from .OrderEngine import OrderEngine

--- a/BayesicFitting/source/SalesmanProblem.py
+++ b/BayesicFitting/source/SalesmanProblem.py
@@ -1,8 +1,6 @@
 import numpy as numpy
-from astropy import units
 import math
 import warnings
-from . import Tools
 
 from .OrderProblem import OrderProblem
 

--- a/BayesicFitting/source/Sample.py
+++ b/BayesicFitting/source/Sample.py
@@ -1,10 +1,8 @@
 import numpy as numpy
 import math
 from . import Tools
-from .Formatter import formatter as fmt
 
 from .Model import Model
-from .Tools import setAttribute as setatt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/SampleList.py
+++ b/BayesicFitting/source/SampleList.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-from astropy import units
 import math
 from . import Tools
 from .Sample import Sample

--- a/BayesicFitting/source/SampleMovie.py
+++ b/BayesicFitting/source/SampleMovie.py
@@ -1,13 +1,10 @@
 
 import numpy as numpy
 import math
-from . import Tools
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
-from .Sample import Sample
-from .SampleList import SampleList
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/ScaledErrorDistribution.py
+++ b/BayesicFitting/source/ScaledErrorDistribution.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-import math
 
 from .ErrorDistribution import ErrorDistribution
 from .NoiseScale import NoiseScale

--- a/BayesicFitting/source/ShuffleEngine.py
+++ b/BayesicFitting/source/ShuffleEngine.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-import math
-from . import Tools
 from .Formatter import formatter as fmt
 
 from .OrderEngine import OrderEngine

--- a/BayesicFitting/source/SineAmpModel.py
+++ b/BayesicFitting/source/SineAmpModel.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-from astropy import units
 import math
 from . import Tools
 from .Tools import setAttribute as setatt

--- a/BayesicFitting/source/SoftMaxModel.py
+++ b/BayesicFitting/source/SoftMaxModel.py
@@ -1,11 +1,7 @@
 import numpy as numpy
 from astropy import units
-import math
-from . import Tools
 from . import NeuralNetUtilities
 from .Tools import setAttribute as setatt
-from .Formatter import formatter as fmt
-from .Formatter import fma
 
 from .NonLinearModel import NonLinearModel
 

--- a/BayesicFitting/source/SplinesDynamicModel.py
+++ b/BayesicFitting/source/SplinesDynamicModel.py
@@ -1,7 +1,5 @@
 import numpy as numpy
-from . import Tools
 from .Tools import setAttribute as setatt
-from .SplinesModel import SplinesModel
 from .BasicSplinesModel import BasicSplinesModel
 from .Dynamic import Dynamic
 from .Modifiable import Modifiable

--- a/BayesicFitting/source/StartEngine.py
+++ b/BayesicFitting/source/StartEngine.py
@@ -1,13 +1,8 @@
 import numpy as numpy
-from astropy import units
 import math
-import warnings
-from . import Tools
 from .Formatter import formatter as fmt
 from .Dynamic import Dynamic
 from .Engine import Engine
-from .ErrorsInXandYProblem import ErrorsInXandYProblem
-from .ModelDistribution import ModelDistribution
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/StartOrderEngine.py
+++ b/BayesicFitting/source/StartOrderEngine.py
@@ -1,7 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
-from . import Tools
 
 from .OrderEngine import OrderEngine
 

--- a/BayesicFitting/source/StellarOrbitModel.py
+++ b/BayesicFitting/source/StellarOrbitModel.py
@@ -5,7 +5,6 @@ from . import Tools
 from .Tools import setAttribute as setatt
 from .NonLinearModel import NonLinearModel
 from .Kepplers2ndLaw import Kepplers2ndLaw
-from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2025

--- a/BayesicFitting/source/StepEngine.py
+++ b/BayesicFitting/source/StepEngine.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-from . import Tools
 from .Formatter import formatter as fmt
 from .Formatter import fma
 

--- a/BayesicFitting/source/StructureEngine.py
+++ b/BayesicFitting/source/StructureEngine.py
@@ -2,7 +2,6 @@ import numpy as numpy
 
 from .Modifiable import Modifiable
 from .Engine import Engine
-from . import Tools
 from .Formatter import formatter as fmt
 
 __author__ = "Do Kester"

--- a/BayesicFitting/source/SwitchEngine.py
+++ b/BayesicFitting/source/SwitchEngine.py
@@ -1,6 +1,4 @@
 import numpy as numpy
-import math
-from . import Tools
 from .Formatter import formatter as fmt
 
 from .OrderEngine import OrderEngine

--- a/BayesicFitting/source/UserModel.py
+++ b/BayesicFitting/source/UserModel.py
@@ -1,9 +1,5 @@
 import numpy as numpy
-from astropy import units
-from astropy.modeling import Model as AstroModel
-import math
 import warnings
-from . import Tools
 from .Tools import setAttribute as setatt
 
 from .Model import Model

--- a/BayesicFitting/source/Walker.py
+++ b/BayesicFitting/source/Walker.py
@@ -1,5 +1,4 @@
 import numpy as numpy
-import math
 from . import Tools
 from .Formatter import formatter as fmt
 

--- a/BayesicFitting/source/WalkerList.py
+++ b/BayesicFitting/source/WalkerList.py
@@ -1,7 +1,4 @@
 import numpy as numpy
-from astropy import units
-import math
-from . import Tools
 from .Tools import setAttribute as setatt
 from .Formatter import formatter as fmt
 from .Walker import Walker

--- a/BayesicFitting/test/TestAmoeba.py
+++ b/BayesicFitting/test/TestAmoeba.py
@@ -3,7 +3,6 @@
 import numpy as numpy
 import os
 import unittest
-from astropy import units
 import math
 import matplotlib.pyplot as plt
 from numpy.testing import assert_array_almost_equal as assertAAE

--- a/BayesicFitting/test/TestAmoebaFitter.py
+++ b/BayesicFitting/test/TestAmoebaFitter.py
@@ -4,8 +4,6 @@ import unittest
 import os
 import numpy as numpy
 from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
-import math
 
 import matplotlib.pyplot as plt
 

--- a/BayesicFitting/test/TestAstropyModel.py
+++ b/BayesicFitting/test/TestAstropyModel.py
@@ -3,12 +3,9 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
 from astropy import modeling
 #from astropy.modeling.models import Gaussian1D
 #from astropy.modeling.models import Polynomial1D
-import matplotlib.pyplot as plt
-import warnings
 
 from StdTests import stdModeltest
 

--- a/BayesicFitting/test/TestBaseFitter.py
+++ b/BayesicFitting/test/TestBaseFitter.py
@@ -5,7 +5,6 @@ import math
 import numpy as np
 from numpy.testing import assert_array_almost_equal as assertAAE
 
-import matplotlib.pyplot as plt
 
 from BayesicFitting import *
 

--- a/BayesicFitting/test/TestBasicSplinesModel.py
+++ b/BayesicFitting/test/TestBasicSplinesModel.py
@@ -3,8 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
 import matplotlib.pyplot as plt
 from numpy.testing import assert_array_almost_equal as assertAAE
 from numpy.testing import assert_array_equal as assertAE

--- a/BayesicFitting/test/TestBracketModel.py
+++ b/BayesicFitting/test/TestBracketModel.py
@@ -4,9 +4,6 @@ import unittest
 import os
 import numpy as numpy
 from numpy.testing import assert_array_equal as assertAE
-from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
-import math
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt

--- a/BayesicFitting/test/TestCombiModel.py
+++ b/BayesicFitting/test/TestCombiModel.py
@@ -4,9 +4,7 @@ import unittest
 import os
 import numpy as numpy
 from numpy.testing import assert_array_equal as assertAE
-from numpy.testing import assert_array_almost_equal as assertAAE
 from astropy import units
-import math
 
 from BayesicFitting import *
 from StdTests import stdModeltest

--- a/BayesicFitting/test/TestCompoundModel.py
+++ b/BayesicFitting/test/TestCompoundModel.py
@@ -3,9 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
-import matplotlib.pyplot as plt
 
 #from BayesicFitting import PolynomialModel, SineModel
 #from Model import Model

--- a/BayesicFitting/test/TestCurveFitter.py
+++ b/BayesicFitting/test/TestCurveFitter.py
@@ -3,9 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
-import math
 
 import matplotlib.pyplot as plt
 

--- a/BayesicFitting/test/TestDecisionTreeModel.py
+++ b/BayesicFitting/test/TestDecisionTreeModel.py
@@ -3,8 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
 import matplotlib.pyplot as plt
 
 from BayesicFitting import *

--- a/BayesicFitting/test/TestDimensions.py
+++ b/BayesicFitting/test/TestDimensions.py
@@ -3,9 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
-import matplotlib.pyplot as plt
 from numpy.testing import assert_array_almost_equal as assertAAE
 
 #from BayesicFitting import PolynomialModel, SineModel
@@ -13,7 +10,6 @@ from numpy.testing import assert_array_almost_equal as assertAAE
 
 from StdTests import stdModeltest as stdMtest
 
-from BayesicFitting import formatter as fmt
 from BayesicFitting import *
 
 __author__ = "Do Kester"

--- a/BayesicFitting/test/TestDistanceCostFunction.py
+++ b/BayesicFitting/test/TestDistanceCostFunction.py
@@ -3,15 +3,10 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-from numpy.testing import assert_array_equal as assertAE
 from numpy.testing import assert_array_almost_equal as assertAAE
-import math
-import matplotlib.pyplot as plt
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt
-from BayesicFitting import fma
 
 
 __author__ = "Do Kester"

--- a/BayesicFitting/test/TestDynamicModel.py
+++ b/BayesicFitting/test/TestDynamicModel.py
@@ -3,8 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
 import matplotlib.pyplot as plt
 
 from StdTests import stdModeltest

--- a/BayesicFitting/test/TestEngine.py
+++ b/BayesicFitting/test/TestEngine.py
@@ -2,10 +2,7 @@
 
 import unittest
 import numpy as numpy
-from astropy import units
 import math
-import matplotlib.pyplot as plt
-from numpy.testing import assert_array_almost_equal as assertAAE
 
 from BayesicFitting import *
 

--- a/BayesicFitting/test/TestEngine2.py
+++ b/BayesicFitting/test/TestEngine2.py
@@ -3,7 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
 import math
 import matplotlib.pyplot as plt
 

--- a/BayesicFitting/test/TestErrorDistribution.py
+++ b/BayesicFitting/test/TestErrorDistribution.py
@@ -6,11 +6,8 @@ import numpy as numpy
 from numpy.testing import assert_array_almost_equal as assertAAE
 import unittest
 import os
-from astropy import units
 import math
-import sys
 import matplotlib.pyplot as plt
-from StdTests import stdModeltest
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt

--- a/BayesicFitting/test/TestErrorDistribution2.py
+++ b/BayesicFitting/test/TestErrorDistribution2.py
@@ -6,11 +6,8 @@ import numpy as numpy
 from numpy.testing import assert_array_almost_equal as assertAAE
 import unittest
 import os
-from astropy import units
 import math
-import sys
 import matplotlib.pyplot as plt
-from StdTests import stdModeltest
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt

--- a/BayesicFitting/test/TestEvidence.py
+++ b/BayesicFitting/test/TestEvidence.py
@@ -4,7 +4,6 @@ import unittest
 import os
 import numpy as np
 import math
-from numpy.testing import assert_array_almost_equal as assertAAE
 
 import matplotlib.pyplot as plt
 from BayesicFitting import *

--- a/BayesicFitting/test/TestFitter.py
+++ b/BayesicFitting/test/TestFitter.py
@@ -2,7 +2,6 @@
 
 import numpy as numpy
 from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
 import unittest
 import os
 import math

--- a/BayesicFitting/test/TestFixedModels.py
+++ b/BayesicFitting/test/TestFixedModels.py
@@ -3,9 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import matplotlib.pyplot as plt
-import warnings
 
 from StdTests import stdModeltest
 from BayesicFitting import *

--- a/BayesicFitting/test/TestFootballModel.py
+++ b/BayesicFitting/test/TestFootballModel.py
@@ -2,18 +2,13 @@
 
 import unittest
 import os
-import math
 import numpy as numpy
-from astropy import units
-from astropy import modeling
 #from astropy.modeling.models import Gaussian1D
 #from astropy.modeling.models import Polynomial1D
 import matplotlib.pyplot as plt
-import warnings
 
 from numpy.testing import assert_array_almost_equal as assertAAE
 from numpy.testing import assert_array_equal as assertAE
-from StdTests import stdModeltest
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt

--- a/BayesicFitting/test/TestFormatter.py
+++ b/BayesicFitting/test/TestFormatter.py
@@ -2,7 +2,6 @@
 
 import unittest
 import numpy as numpy
-import math
 
 from BayesicFitting import formatter as fmt
 from BayesicFitting import formatter_init as fmtinit

--- a/BayesicFitting/test/TestFreeShapeModel.py
+++ b/BayesicFitting/test/TestFreeShapeModel.py
@@ -3,9 +3,7 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
 import matplotlib.pyplot as plt
-import warnings
 
 from StdTests import stdModeltest
 

--- a/BayesicFitting/test/TestImageAssistant.py
+++ b/BayesicFitting/test/TestImageAssistant.py
@@ -4,11 +4,7 @@ import unittest
 import os
 import numpy as numpy
 from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
-import matplotlib.pyplot as plt
-import warnings
 
-from BayesicFitting import PolySurfaceModel
 from BayesicFitting import ImageAssistant
 
 __author__ = "Do Kester"

--- a/BayesicFitting/test/TestKepplers2ndLaw.py
+++ b/BayesicFitting/test/TestKepplers2ndLaw.py
@@ -4,12 +4,9 @@ import unittest
 import os
 import numpy as numpy
 import math
-from astropy import units
 import matplotlib.pyplot as plt
-import warnings
 from numpy.testing import assert_array_almost_equal as assertAAE
 
-from StdTests import stdModeltest
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt

--- a/BayesicFitting/test/TestKernel2dModel.py
+++ b/BayesicFitting/test/TestKernel2dModel.py
@@ -2,8 +2,6 @@
 
 import unittest
 import numpy as numpy
-from astropy import units
-import math
 from numpy.testing import assert_array_almost_equal as assertAAE
 
 from BayesicFitting import formatter as fmt

--- a/BayesicFitting/test/TestKernels.py
+++ b/BayesicFitting/test/TestKernels.py
@@ -5,7 +5,6 @@ import os
 import numpy as numpy
 from astropy import units
 import matplotlib.pyplot as plt
-import warnings
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt

--- a/BayesicFitting/test/TestLMFitter.py
+++ b/BayesicFitting/test/TestLMFitter.py
@@ -4,8 +4,6 @@ import unittest
 import os
 import numpy as numpy
 from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
-import math
 
 import matplotlib.pyplot as plt
 

--- a/BayesicFitting/test/TestLogFactorial.py
+++ b/BayesicFitting/test/TestLogFactorial.py
@@ -4,9 +4,6 @@ import unittest
 import numpy as numpy
 import math
 from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
-import matplotlib.pyplot as plt
-import warnings
 
 from BayesicFitting import logFactorial
 

--- a/BayesicFitting/test/TestModels.py
+++ b/BayesicFitting/test/TestModels.py
@@ -3,9 +3,7 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
 import matplotlib.pyplot as plt
-import warnings
 
 from StdTests import stdModeltest
 

--- a/BayesicFitting/test/TestModifiable.py
+++ b/BayesicFitting/test/TestModifiable.py
@@ -3,7 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
 import math
 import matplotlib.pyplot as plt
 

--- a/BayesicFitting/test/TestMonteCarlo.py
+++ b/BayesicFitting/test/TestMonteCarlo.py
@@ -5,7 +5,6 @@ import os
 import numpy as numpy
 from numpy.testing import assert_array_almost_equal as assertAAE
 
-from astropy import units
 import math
 import matplotlib.pyplot as pyplot
 

--- a/BayesicFitting/test/TestNLFitters.py
+++ b/BayesicFitting/test/TestNLFitters.py
@@ -3,11 +3,7 @@
 import unittest
 import os
 import numpy as numpy
-from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
-import math
 
-import matplotlib.pyplot as plt
 
 from BayesicFitting import *
 

--- a/BayesicFitting/test/TestNNUtilities.py
+++ b/BayesicFitting/test/TestNNUtilities.py
@@ -2,10 +2,6 @@
 
 import unittest
 import numpy as numpy
-from astropy import units
-import math
-import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 
 from BayesicFitting import formatter as fmt
 

--- a/BayesicFitting/test/TestNestedSampler.py
+++ b/BayesicFitting/test/TestNestedSampler.py
@@ -3,14 +3,9 @@
 
 import unittest
 import os
-import time
 import numpy as numpy
-from astropy import units
 import math
-from numpy.testing import assert_array_almost_equal as assertAAE
-from FitPlot import plotFit
 
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from BayesicFitting import *

--- a/BayesicFitting/test/TestNestedSolver.py
+++ b/BayesicFitting/test/TestNestedSolver.py
@@ -3,14 +3,11 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-from numpy.testing import assert_array_equal as assertAE
 import math
 import matplotlib.pyplot as plt
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt
-from BayesicFitting import fma
 
 
 __author__ = "Do Kester"

--- a/BayesicFitting/test/TestOrderEngines.py
+++ b/BayesicFitting/test/TestOrderEngines.py
@@ -3,14 +3,12 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
 from numpy.testing import assert_array_equal as assertAE
 import math
 import matplotlib.pyplot as plt
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt
-from BayesicFitting import fma
 
 
 __author__ = "Do Kester"

--- a/BayesicFitting/test/TestOrthonormalBasis.py
+++ b/BayesicFitting/test/TestOrthonormalBasis.py
@@ -2,9 +2,7 @@
 
 import unittest
 import numpy as numpy
-from astropy import units
 import math
-import matplotlib.pyplot as plt
 from numpy.testing import assert_array_almost_equal as assertAAE
 
 from BayesicFitting import *

--- a/BayesicFitting/test/TestPhantomCollection.py
+++ b/BayesicFitting/test/TestPhantomCollection.py
@@ -1,14 +1,9 @@
 # run with : python3 -m unittest TestPhantomCollection
 
 import unittest
-import numpy as np
-import math
 import os
 
-from numpy.testing import assert_array_equal as assertAE
-from numpy.testing import assert_array_almost_equal as assertAAE
 
-import matplotlib.pyplot as plt
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt
 

--- a/BayesicFitting/test/TestPhantomSampler.py
+++ b/BayesicFitting/test/TestPhantomSampler.py
@@ -3,12 +3,8 @@
 
 import unittest
 import os
-import time
 import numpy as numpy
-from astropy import units
 import math
-from numpy.testing import assert_array_almost_equal as assertAAE
-from FitPlot import plotFit
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt

--- a/BayesicFitting/test/TestPipeModel.py
+++ b/BayesicFitting/test/TestPipeModel.py
@@ -3,9 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
-import matplotlib.pyplot as plt
 
 #from BayesicFitting import PolynomialModel, SineModel
 #from Model import Model

--- a/BayesicFitting/test/TestPlot.py
+++ b/BayesicFitting/test/TestPlot.py
@@ -1,10 +1,7 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
 import matplotlib.pyplot as plt
-from BayesicFitting import formatter as fmt
 
 from BayesicFitting import *
 

--- a/BayesicFitting/test/TestProblem.py
+++ b/BayesicFitting/test/TestProblem.py
@@ -6,9 +6,7 @@ import numpy as numpy
 import os
 from numpy.testing import assert_array_almost_equal as assertAAE
 import unittest
-from astropy import units
 import math
-import sys
 import matplotlib.pyplot as plt
 
 from BayesicFitting import *

--- a/BayesicFitting/test/TestQRFitter.py
+++ b/BayesicFitting/test/TestQRFitter.py
@@ -3,7 +3,6 @@
 import numpy as numpy
 import os
 from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
 import unittest
 import FitPlot
 

--- a/BayesicFitting/test/TestRobustShell.py
+++ b/BayesicFitting/test/TestRobustShell.py
@@ -3,8 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
 import matplotlib.pyplot as plt
 from numpy.testing import assert_array_almost_equal as assertAAE
 

--- a/BayesicFitting/test/TestSalesmanProblem.py
+++ b/BayesicFitting/test/TestSalesmanProblem.py
@@ -3,15 +3,11 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-from numpy.testing import assert_array_equal as assertAE
 from numpy.testing import assert_array_almost_equal as assertAAE
 import math
-import matplotlib.pyplot as plt
 
 from BayesicFitting import *
 from BayesicFitting import formatter as fmt
-from BayesicFitting import fma
 
 
 __author__ = "Do Kester"

--- a/BayesicFitting/test/TestSampleList.py
+++ b/BayesicFitting/test/TestSampleList.py
@@ -4,7 +4,6 @@ import unittest
 import numpy as numpy
 import sys
 from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
 import math
 
 from BayesicFitting import *

--- a/BayesicFitting/test/TestSoftMaxModel.py
+++ b/BayesicFitting/test/TestSoftMaxModel.py
@@ -3,10 +3,7 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
 import matplotlib.pyplot as plt
-import warnings
 
 from numpy.testing import assert_array_almost_equal as assertAAE
 from StdTests import stdModeltest

--- a/BayesicFitting/test/TestStartEngine.py
+++ b/BayesicFitting/test/TestStartEngine.py
@@ -3,7 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
 import math
 import matplotlib.pyplot as plt
 

--- a/BayesicFitting/test/TestStellarOrbitModel.py
+++ b/BayesicFitting/test/TestStellarOrbitModel.py
@@ -3,16 +3,12 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
 import math
 import matplotlib.pyplot as plt
-import warnings
 
 from numpy.testing import assert_array_almost_equal as assertAAE
-from StdTests import stdModeltest
 
 from BayesicFitting import *
-from BayesicFitting import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2017

--- a/BayesicFitting/test/TestTools.py
+++ b/BayesicFitting/test/TestTools.py
@@ -3,7 +3,6 @@
 import unittest
 import numpy as numpy
 import math
-import inspect
 from datetime import date
 
 from BayesicFitting import *

--- a/BayesicFitting/test/TestUserModel.py
+++ b/BayesicFitting/test/TestUserModel.py
@@ -4,19 +4,13 @@ import unittest
 import os
 import math
 import numpy as numpy
-from astropy import units
-from astropy import modeling
 #from astropy.modeling.models import Gaussian1D
 #from astropy.modeling.models import Polynomial1D
-import matplotlib.pyplot as plt
-import warnings
 
-from numpy.testing import assert_array_almost_equal as assertAAE
 from numpy.testing import assert_array_equal as assertAE
 from StdTests import stdModeltest
 
 from BayesicFitting import *
-from BayesicFitting import formatter as fmt
 
 __author__ = "Do Kester"
 __year__ = 2017

--- a/BayesicFitting/test/TestWalkerList.py
+++ b/BayesicFitting/test/TestWalkerList.py
@@ -2,9 +2,6 @@
 
 import unittest
 import numpy as numpy
-import sys
-from numpy.testing import assert_array_almost_equal as assertAAE
-from astropy import units
 import math
 
 from BayesicFitting import *

--- a/BayesicFitting/test/TestWeight2.py
+++ b/BayesicFitting/test/TestWeight2.py
@@ -3,8 +3,6 @@
 import unittest
 import os
 import numpy as numpy
-from astropy import units
-import math
 from numpy.testing import assert_array_almost_equal as assertAAE
 
 from BayesicFitting import *


### PR DESCRIPTION
Hello. Turns out this package is used by https://github.com/spacetelescope/jwst . I noticed that this package imports matplotlib when it does not have to, which cause some problem downstream because we do not really require matplotlib. I decided to remove all unused imports from this package. The fastest way to accomplish this is using https://docs.astral.sh/ruff/rules/unused-import/ and https://pre-commit.com/ via `pre-commit run --all-files`.

Hope you take this patch into consideration. Thank you.